### PR TITLE
Rename to radi

### DIFF
--- a/bytesource/base.go
+++ b/bytesource/base.go
@@ -1,7 +1,7 @@
 package bytesource
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 /**

--- a/bytesource/base.go
+++ b/bytesource/base.go
@@ -1,7 +1,7 @@
 package bytesource
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 /**

--- a/bytesource/file_configconnect_yml.go
+++ b/bytesource/file_configconnect_yml.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
 )
 
 const (

--- a/bytesource/file_configconnect_yml.go
+++ b/bytesource/file_configconnect_yml.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
 )
 
 const (

--- a/configwrapper/builder_yaml.go
+++ b/configwrapper/builder_yaml.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	api_builder "github.com/james-nesbitt/kraut-api/builder"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+	api_builder "github.com/james-nesbitt/radi-api/builder"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
 )
 
 /**

--- a/configwrapper/builder_yaml.go
+++ b/configwrapper/builder_yaml.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	api_builder "github.com/james-nesbitt/radi-api/builder"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_builder "github.com/wunderkraut/radi-api/builder"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
 )
 
 /**

--- a/configwrapper/security.go
+++ b/configwrapper/security.go
@@ -1,8 +1,8 @@
 package configwrapper
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
 )
 
 /**

--- a/configwrapper/security.go
+++ b/configwrapper/security.go
@@ -1,8 +1,8 @@
 package configwrapper
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
 )
 
 /**

--- a/configwrapper/security_yaml.go
+++ b/configwrapper/security_yaml.go
@@ -6,9 +6,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	// "gopkg.in/yaml.v2"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
 )
 
 // Constructor for SecurityConfigWrapperYml

--- a/configwrapper/security_yaml.go
+++ b/configwrapper/security_yaml.go
@@ -6,9 +6,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	// "gopkg.in/yaml.v2"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
 )
 
 // Constructor for SecurityConfigWrapperYml

--- a/configwrapper/security_yaml_authorization.go
+++ b/configwrapper/security_yaml_authorization.go
@@ -7,9 +7,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	// api_config "github.com/james-nesbitt/radi-api/operation/config"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	// api_config "github.com/wunderkraut/radi-api/operation/config"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
 )
 
 /**

--- a/configwrapper/security_yaml_authorization.go
+++ b/configwrapper/security_yaml_authorization.go
@@ -7,9 +7,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	// api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	// api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
 )
 
 /**

--- a/configwrapper/security_yaml_user.go
+++ b/configwrapper/security_yaml_user.go
@@ -7,9 +7,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	// api_operation "github.com/james-nesbitt/kraut-api/operation"
-	// api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
+	// api_operation "github.com/james-nesbitt/radi-api/operation"
+	// api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
 )
 
 // Retrieve values by parsing bytes from the wrapper

--- a/configwrapper/security_yaml_user.go
+++ b/configwrapper/security_yaml_user.go
@@ -7,9 +7,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	// api_operation "github.com/james-nesbitt/radi-api/operation"
-	// api_config "github.com/james-nesbitt/radi-api/operation/config"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	// api_operation "github.com/wunderkraut/radi-api/operation"
+	// api_config "github.com/wunderkraut/radi-api/operation/config"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
 )
 
 // Retrieve values by parsing bytes from the wrapper

--- a/configwrapper/setting.go
+++ b/configwrapper/setting.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_setting "github.com/wunderkraut/radi-api/operation/setting"
 )
 
 const (

--- a/configwrapper/setting.go
+++ b/configwrapper/setting.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_setting "github.com/james-nesbitt/kraut-api/operation/setting"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
 )
 
 const (

--- a/configwrapper/setting_yaml.go
+++ b/configwrapper/setting_yaml.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
 )
 
 /**

--- a/configwrapper/setting_yaml.go
+++ b/configwrapper/setting_yaml.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
 )
 
 /**

--- a/configwrapper/ymltools.go
+++ b/configwrapper/ymltools.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 // Convert Authorize string to int, invert it if asked to

--- a/configwrapper/ymltools.go
+++ b/configwrapper/ymltools.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 // Convert Authorize string to int, invert it if asked to

--- a/libcompose/base.go
+++ b/libcompose/base.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
 )
 
 /**

--- a/libcompose/base.go
+++ b/libcompose/base.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
 )
 
 /**

--- a/libcompose/command.go
+++ b/libcompose/command.go
@@ -3,8 +3,8 @@ package libcompose
 import (
 	"errors"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_command "github.com/james-nesbitt/radi-api/operation/command"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_command "github.com/wunderkraut/radi-api/operation/command"
 )
 
 /**

--- a/libcompose/command.go
+++ b/libcompose/command.go
@@ -3,8 +3,8 @@ package libcompose
 import (
 	"errors"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_command "github.com/james-nesbitt/kraut-api/operation/command"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_command "github.com/james-nesbitt/radi-api/operation/command"
 )
 
 /**

--- a/libcompose/command_yaml.go
+++ b/libcompose/command_yaml.go
@@ -11,9 +11,9 @@ import (
 	libCompose_config "github.com/docker/libcompose/config"
 	libCompose_project_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_command "github.com/james-nesbitt/kraut-api/operation/command"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_command "github.com/james-nesbitt/radi-api/operation/command"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
 )
 
 // Constructor for BaseCommandConfigWrapperYmlOperation

--- a/libcompose/command_yaml.go
+++ b/libcompose/command_yaml.go
@@ -11,9 +11,9 @@ import (
 	libCompose_config "github.com/docker/libcompose/config"
 	libCompose_project_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_command "github.com/james-nesbitt/radi-api/operation/command"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_command "github.com/wunderkraut/radi-api/operation/command"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
 )
 
 // Constructor for BaseCommandConfigWrapperYmlOperation

--- a/libcompose/libcompose.go
+++ b/libcompose/libcompose.go
@@ -10,8 +10,8 @@ import (
 	libCompose_dockerctx "github.com/docker/libcompose/docker/ctx"
 	libCompose_project "github.com/docker/libcompose/project"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
 )
 
 /**

--- a/libcompose/libcompose.go
+++ b/libcompose/libcompose.go
@@ -10,8 +10,8 @@ import (
 	libCompose_dockerctx "github.com/docker/libcompose/docker/ctx"
 	libCompose_project "github.com/docker/libcompose/project"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
 )
 
 /**

--- a/libcompose/monitor.go
+++ b/libcompose/monitor.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/net/context"
 	log "github.com/Sirupsen/logrus"	
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_monitor "github.com/wunderkraut/radi-api/operation/monitor"
 )
 
 /**

--- a/libcompose/monitor.go
+++ b/libcompose/monitor.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/net/context"
 	log "github.com/Sirupsen/logrus"	
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_monitor "github.com/james-nesbitt/kraut-api/operation/monitor"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
 )
 
 /**

--- a/libcompose/orchestrate_down.go
+++ b/libcompose/orchestrate_down.go
@@ -8,8 +8,8 @@ import (
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"
 )
 
 const (

--- a/libcompose/orchestrate_down.go
+++ b/libcompose/orchestrate_down.go
@@ -8,8 +8,8 @@ import (
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
 )
 
 const (

--- a/libcompose/orchestrate_start.go
+++ b/libcompose/orchestrate_start.go
@@ -6,8 +6,8 @@ import (
 	// log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"
 )
 
 // Base Start operation

--- a/libcompose/orchestrate_start.go
+++ b/libcompose/orchestrate_start.go
@@ -6,8 +6,8 @@ import (
 	// log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
 )
 
 // Base Start operation

--- a/libcompose/orchestrate_stop.go
+++ b/libcompose/orchestrate_stop.go
@@ -6,8 +6,8 @@ import (
 	// log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
 )
 
 // Base Stop operation

--- a/libcompose/orchestrate_stop.go
+++ b/libcompose/orchestrate_stop.go
@@ -6,8 +6,8 @@ import (
 	// log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"
 )
 
 // Base Stop operation

--- a/libcompose/orchestrate_up.go
+++ b/libcompose/orchestrate_up.go
@@ -8,8 +8,8 @@ import (
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"
 )
 
 const (

--- a/libcompose/orchestrate_up.go
+++ b/libcompose/orchestrate_up.go
@@ -8,8 +8,8 @@ import (
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
 )
 
 const (

--- a/libcompose/property.go
+++ b/libcompose/property.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	// libCompose_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 const (

--- a/libcompose/property.go
+++ b/libcompose/property.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	// libCompose_options "github.com/docker/libcompose/project/options"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 const (

--- a/local/api.go
+++ b/local/api.go
@@ -3,7 +3,7 @@ package local
 import (
 	"golang.org/x/net/context"
 
-	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"
+	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
 )
 
 // Settings needed to make a local API

--- a/local/api.go
+++ b/local/api.go
@@ -3,7 +3,7 @@ package local
 import (
 	"golang.org/x/net/context"
 
-	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
+	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
 )
 
 // Settings needed to make a local API

--- a/local/base.go
+++ b/local/base.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
-	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
+	api_setting "github.com/wunderkraut/radi-api/operation/setting"
 )
 
 /**

--- a/local/base.go
+++ b/local/base.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	api_setting "github.com/james-nesbitt/kraut-api/operation/setting"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
 )
 
 /**

--- a/local/builder.go
+++ b/local/builder.go
@@ -6,16 +6,16 @@ import (
 	"os"
 	"path"
 
-	api_api "github.com/james-nesbitt/radi-api/api"
-	api_builder "github.com/james-nesbitt/radi-api/builder"
-	api_handler "github.com/james-nesbitt/radi-api/handler"
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_command "github.com/james-nesbitt/radi-api/operation/command"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
-	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
-	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
-	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
+	api_api "github.com/wunderkraut/radi-api/api"
+	api_builder "github.com/wunderkraut/radi-api/builder"
+	api_handler "github.com/wunderkraut/radi-api/handler"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_command "github.com/wunderkraut/radi-api/operation/command"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
+	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
+	api_setting "github.com/wunderkraut/radi-api/operation/setting"
+	handlers_libcompose "github.com/wunderkraut/radi-handlers/libcompose"
 )
 
 /**

--- a/local/builder.go
+++ b/local/builder.go
@@ -6,16 +6,16 @@ import (
 	"os"
 	"path"
 
-	api_api "github.com/james-nesbitt/kraut-api/api"
-	api_builder "github.com/james-nesbitt/kraut-api/builder"
-	api_handler "github.com/james-nesbitt/kraut-api/handler"
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_command "github.com/james-nesbitt/kraut-api/operation/command"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
-	api_setting "github.com/james-nesbitt/kraut-api/operation/setting"
-	handlers_libcompose "github.com/james-nesbitt/kraut-handlers/libcompose"
+	api_api "github.com/james-nesbitt/radi-api/api"
+	api_builder "github.com/james-nesbitt/radi-api/builder"
+	api_handler "github.com/james-nesbitt/radi-api/handler"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_command "github.com/james-nesbitt/radi-api/operation/command"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
+	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
 )
 
 /**

--- a/local/command.go
+++ b/local/command.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_command "github.com/james-nesbitt/kraut-api/operation/command"
-	handlers_libcompose "github.com/james-nesbitt/kraut-handlers/libcompose"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_command "github.com/james-nesbitt/radi-api/operation/command"
+	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
 )
 
 /**

--- a/local/command.go
+++ b/local/command.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_command "github.com/james-nesbitt/radi-api/operation/command"
-	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_command "github.com/wunderkraut/radi-api/operation/command"
+	handlers_libcompose "github.com/wunderkraut/radi-handlers/libcompose"
 )
 
 /**

--- a/local/config.go
+++ b/local/config.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
 )
 
 // A handler for local config

--- a/local/config.go
+++ b/local/config.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
-	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
+	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
 )
 
 // A handler for local config

--- a/local/monitor.go
+++ b/local/monitor.go
@@ -1,8 +1,8 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	handlers_libcompose "github.com/james-nesbitt/kraut-handlers/libcompose"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
 )
 
 // A handler for local monitoring using libcompose

--- a/local/monitor.go
+++ b/local/monitor.go
@@ -1,8 +1,8 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	handlers_libcompose "github.com/wunderkraut/radi-handlers/libcompose"
 )
 
 // A handler for local monitoring using libcompose

--- a/local/orchestrate.go
+++ b/local/orchestrate.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
-	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"
+	handlers_libcompose "github.com/wunderkraut/radi-handlers/libcompose"
 )
 
 // A handler for local orchestration using libcompose

--- a/local/orchestrate.go
+++ b/local/orchestrate.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
-	handlers_libcompose "github.com/james-nesbitt/kraut-handlers/libcompose"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
+	handlers_libcompose "github.com/james-nesbitt/radi-handlers/libcompose"
 )
 
 // A handler for local orchestration using libcompose

--- a/local/project.go
+++ b/local/project.go
@@ -8,9 +8,9 @@ import (
 
 	jn_init "github.com/james-nesbitt/init-go"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_project "github.com/james-nesbitt/kraut-api/operation/project"
-	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_project "github.com/james-nesbitt/radi-api/operation/project"
+	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
 )
 
 /**
@@ -45,7 +45,7 @@ func (handler *LocalHandler_Project) Init() api_operation.Result {
 }
 
 /**
- * Operation to initialize the current project as a kraut project
+ * Operation to initialize the current project as a radi project
  */
 
 type LocalProjectInitOperation struct {
@@ -63,7 +63,7 @@ func (init *LocalProjectInitOperation) Id() string {
 
 // Description for the LocalProjectCreateOperation
 func (init *LocalProjectInitOperation) Description() string {
-	return "Initialize the current project path as a kraut project"
+	return "Initialize the current project path as a radi project"
 }
 
 // Validate the operation
@@ -98,9 +98,9 @@ func (init *LocalProjectInitOperation) Exec() api_operation.Result {
 
 	demoMode := demoModeProp.Get().(bool)
 
-	source := "https://raw.githubusercontent.com/james-nesbitt/kraut-handlers/master/local/template/minimal-init.yml"
+	source := "https://raw.githubusercontent.com/james-nesbitt/radi-handlers/master/local/template/minimal-init.yml"
 	if demoMode {
-		source = "https://raw.githubusercontent.com/james-nesbitt/kraut-handlers/master/local/template/demo-init.yml"
+		source = "https://raw.githubusercontent.com/james-nesbitt/radi-handlers/master/local/template/demo-init.yml"
 	}
 
 	settings := settingsProp.Get().(handlers_bytesource.BytesourceFileSettings)
@@ -260,7 +260,7 @@ func (generate *LocalProjectGenerateOperation) Exec() api_operation.Result {
 		log.WithFields(log.Fields{"root": settings.ProjectRootPath, "path": destination}).Info("Running YML generator")
 
 		/** @TODO REMOVE THIS HARDCODED PATH : make skip allow full paths*/
-		skip = append(skip, "kraut/init.yml")
+		skip = append(skip, "radi/init.yml")
 
 		if fileWriter, err := destination.Writer(); err != nil {
 			log.WithError(err).Error("Failed to create template file")

--- a/local/project.go
+++ b/local/project.go
@@ -6,11 +6,11 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	jn_init "github.com/james-nesbitt/init-go"
+	jn_init "github.com/wunderkraut/init-go"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_project "github.com/james-nesbitt/radi-api/operation/project"
-	handlers_bytesource "github.com/james-nesbitt/radi-handlers/bytesource"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_project "github.com/wunderkraut/radi-api/operation/project"
+	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
 )
 
 /**
@@ -98,9 +98,9 @@ func (init *LocalProjectInitOperation) Exec() api_operation.Result {
 
 	demoMode := demoModeProp.Get().(bool)
 
-	source := "https://raw.githubusercontent.com/james-nesbitt/radi-handlers/master/local/template/minimal-init.yml"
+	source := "https://raw.githubusercontent.com/wunderkraut/radi-handlers/master/local/template/minimal-init.yml"
 	if demoMode {
-		source = "https://raw.githubusercontent.com/james-nesbitt/radi-handlers/master/local/template/demo-init.yml"
+		source = "https://raw.githubusercontent.com/wunderkraut/radi-handlers/master/local/template/demo-init.yml"
 	}
 
 	settings := settingsProp.Get().(handlers_bytesource.BytesourceFileSettings)

--- a/local/security.go
+++ b/local/security.go
@@ -1,10 +1,10 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
-	handlers_configwrapper "github.com/james-nesbitt/radi-handlers/configwrapper"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
+	handlers_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
 )
 
 /**

--- a/local/security.go
+++ b/local/security.go
@@ -1,10 +1,10 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
-	handlers_configwrapper "github.com/james-nesbitt/kraut-handlers/configwrapper"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	handlers_configwrapper "github.com/james-nesbitt/radi-handlers/configwrapper"
 )
 
 /**

--- a/local/setting.go
+++ b/local/setting.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
-	handlers_configwrapper "github.com/james-nesbitt/radi-handlers/configwrapper"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_setting "github.com/wunderkraut/radi-api/operation/setting"
+	handlers_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
 )
 
 // A handler for local settings

--- a/local/setting.go
+++ b/local/setting.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_setting "github.com/james-nesbitt/kraut-api/operation/setting"
-	handlers_configwrapper "github.com/james-nesbitt/kraut-handlers/configwrapper"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
+	handlers_configwrapper "github.com/james-nesbitt/radi-handlers/configwrapper"
 )
 
 // A handler for local settings

--- a/local/template/demo-init.yml
+++ b/local/template/demo-init.yml
@@ -7490,7 +7490,7 @@
     source/composer.lock
     
 - Type: File
-  path: .kraut/settings.yml
+  path: .radi/settings.yml
   Contents: |2
     Author: James Nesbitt
     Client: Internal
@@ -7502,7 +7502,7 @@
     time: Mon Oct 24 14:51:39 EEST 2016
     
 - Type: File
-  path: .kraut/commands.yml
+  path: .radi/commands.yml
   Contents: |2
     
     shell:
@@ -7624,7 +7624,7 @@
     			}
     		},
     		{
-    			"file": ".kraut/settings.yml",
+    			"file": ".radi/settings.yml",
     			"settings":
     			{
     				"buffer_size": 151,
@@ -7676,7 +7676,7 @@
     			}
     		},
     		{
-    			"file": ".kraut/commands.yml",
+    			"file": ".radi/commands.yml",
     			"settings":
     			{
     				"buffer_size": 1794,
@@ -7726,7 +7726,7 @@
     	"expanded_folders":
     	[
     		"/home/james/Documents/Test/wundertest",
-    		"/home/james/Documents/Test/wundertest/.kraut",
+    		"/home/james/Documents/Test/wundertest/.radi",
     		"/home/james/Documents/Test/wundertest/settings",
     		"/home/james/Documents/Test/wundertest/settings/drupal-console",
     		"/home/james/Documents/Test/wundertest/settings/drush",
@@ -7737,18 +7737,18 @@
     	],
     	"file_history":
     	[
-    		"/home/james/Documents/Developer/docker/tools/kraut/kraut-cli/build/.os-detect",
-    		"/home/james/Documents/Test/wundertest/kraut/init.yml",
+    		"/home/james/Documents/Developer/docker/tools/radi/radi-cli/build/.os-detect",
+    		"/home/james/Documents/Test/wundertest/radi/init.yml",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/build/getdeps",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/build.sh",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/Makefile",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/operation/project/create.go",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/project.go",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/bytesource/file.go",
-    		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/initialize/templates/wundertools/kraut/README.md",
-    		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/initialize/templates/wundertools/kraut/commands.yml",
+    		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/initialize/templates/wundertools/radi/README.md",
+    		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/initialize/templates/wundertools/radi/commands.yml",
     		"/home/james/Documents/Test/wundertest/.gitignore",
-    		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/initialize/templates/wundertools/kraut/init.yml",
+    		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/initialize/templates/wundertools/radi/init.yml",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/operation/project/generate.go",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/api/handler/local/initialize/init.go",
     		"/home/james/Documents/Developer/docker/tools/wundertools-go/cli/local/properties.go",
@@ -8188,7 +8188,7 @@
     				},
     				{
     					"buffer": 1,
-    					"file": ".kraut/settings.yml",
+    					"file": ".radi/settings.yml",
     					"semi_transient": true,
     					"settings":
     					{
@@ -8366,7 +8366,7 @@
     				},
     				{
     					"buffer": 7,
-    					"file": ".kraut/commands.yml",
+    					"file": ".radi/commands.yml",
     					"semi_transient": false,
     					"settings":
     					{

--- a/local/template/minimal-init.yml
+++ b/local/template/minimal-init.yml
@@ -1,8 +1,8 @@
 - Type: File
-  path: .kraut/settings.yml
+  path: .radi/settings.yml
   Contents: |2
     Project: wundertest
 - Type: File
-  path: .kraut/commands.yml
+  path: .radi/commands.yml
   Contents: |2
     

--- a/null/base.go
+++ b/null/base.go
@@ -1,7 +1,7 @@
 package null
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 /**

--- a/null/base.go
+++ b/null/base.go
@@ -1,7 +1,7 @@
 package null
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 /**

--- a/null/builder.go
+++ b/null/builder.go
@@ -1,10 +1,10 @@
 package null
 
 import (
-	api_api "github.com/james-nesbitt/kraut-api/api"
-	api_builder "github.com/james-nesbitt/kraut-api/builder"
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_monitor "github.com/james-nesbitt/kraut-api/operation/monitor"
+	api_api "github.com/james-nesbitt/radi-api/api"
+	api_builder "github.com/james-nesbitt/radi-api/builder"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
 )
 
 /**

--- a/null/builder.go
+++ b/null/builder.go
@@ -1,10 +1,10 @@
 package null
 
 import (
-	api_api "github.com/james-nesbitt/radi-api/api"
-	api_builder "github.com/james-nesbitt/radi-api/builder"
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
+	api_api "github.com/wunderkraut/radi-api/api"
+	api_builder "github.com/wunderkraut/radi-api/builder"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_monitor "github.com/wunderkraut/radi-api/operation/monitor"
 )
 
 /**

--- a/null/handler.go
+++ b/null/handler.go
@@ -6,8 +6,8 @@ package null
  */
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_monitor "github.com/james-nesbitt/kraut-api/operation/monitor"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
 )
 
 // NullHandler Constructor, doesn't do much preprocessing really

--- a/null/handler.go
+++ b/null/handler.go
@@ -6,8 +6,8 @@ package null
  */
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_monitor "github.com/wunderkraut/radi-api/operation/monitor"
 )
 
 // NullHandler Constructor, doesn't do much preprocessing really

--- a/null/operation.go
+++ b/null/operation.go
@@ -5,14 +5,14 @@ package null
  */
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_command "github.com/james-nesbitt/kraut-api/operation/command"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
-	api_document "github.com/james-nesbitt/kraut-api/operation/document"
-	api_monitor "github.com/james-nesbitt/kraut-api/operation/monitor"
-	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
-	api_setting "github.com/james-nesbitt/kraut-api/operation/setting"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_command "github.com/james-nesbitt/radi-api/operation/command"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_document "github.com/james-nesbitt/radi-api/operation/document"
+	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
+	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
 )
 
 /**

--- a/null/operation.go
+++ b/null/operation.go
@@ -5,14 +5,14 @@ package null
  */
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_command "github.com/james-nesbitt/radi-api/operation/command"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
-	api_document "github.com/james-nesbitt/radi-api/operation/document"
-	api_monitor "github.com/james-nesbitt/radi-api/operation/monitor"
-	api_orchestrate "github.com/james-nesbitt/radi-api/operation/orchestrate"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
-	api_setting "github.com/james-nesbitt/radi-api/operation/setting"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_command "github.com/wunderkraut/radi-api/operation/command"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
+	api_document "github.com/wunderkraut/radi-api/operation/document"
+	api_monitor "github.com/wunderkraut/radi-api/operation/monitor"
+	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
+	api_setting "github.com/wunderkraut/radi-api/operation/setting"
 )
 
 /**

--- a/null/wrapper.go
+++ b/null/wrapper.go
@@ -1,8 +1,8 @@
 package null
 
 import (
-	"github.com/james-nesbitt/radi-api/operation/command"
-	"github.com/james-nesbitt/radi-api/operation/config"
+	"github.com/wunderkraut/radi-api/operation/command"
+	"github.com/wunderkraut/radi-api/operation/config"
 )
 
 type NullConfigWrapper struct{}

--- a/null/wrapper.go
+++ b/null/wrapper.go
@@ -1,8 +1,8 @@
 package null
 
 import (
-	"github.com/james-nesbitt/kraut-api/operation/command"
-	"github.com/james-nesbitt/kraut-api/operation/config"
+	"github.com/james-nesbitt/radi-api/operation/command"
+	"github.com/james-nesbitt/radi-api/operation/config"
 )
 
 type NullConfigWrapper struct{}

--- a/package.go
+++ b/package.go
@@ -1,1 +1,1 @@
-package krauthandlers
+package radihandlers

--- a/rancher/base.go
+++ b/rancher/base.go
@@ -1,0 +1,34 @@
+package rancher
+
+/**
+ * Some base structs to share upcloud functionality
+ */
+
+// Shared base handler
+type RancherBaseHandler struct {
+	settings RancherSettings
+
+	operations *api_operation.Operations
+}
+
+// Constructor for RancherBaseHandler
+func New_RancherBaseHandler(settings RancherSettings) *RancherBaseHandler {
+	return &RancherBaseHandler{
+		settings: settings,
+		operations: &api_operation.Opeartions{},
+	}
+}
+
+// Get the operations from the handler
+func (base *RancherBaseHandler) Operations() *api_operation.Operations {
+	if base.operations == nil {
+		return &api_operation.Operations{}
+	} else {
+		return base.operations
+	}
+}
+
+// Retrieve the base settings
+func (base *RnacherBaseHandler) Settings() RancherSettings {
+	return base.settings
+}

--- a/rancher/builder.go
+++ b/rancher/builder.go
@@ -1,0 +1,24 @@
+package rancher
+
+import (
+	"time"
+)
+
+/**
+ * Handler builder and settings to create rancher handlers
+ */
+
+type RancherBuilder struct {
+	settings RancherSettings
+
+	parent   api_api.API
+	handlers api_handler.Handlers	
+}
+
+// All of the settings needed to get a Rancher client connection : see github.com/rancher/go-rancher/client/ClientOpts
+type RancherSettings {
+	Url       string	`yaml:"Url"`
+	AccessKey string	`yaml:"AccessKey"`
+	SecretKey string	`yaml:"SecretKey"`
+	Timeout   time.Duration  `yaml:"Timeout"`
+}

--- a/rancher/orchestrate.go
+++ b/rancher/orchestrate.go
@@ -1,0 +1,6 @@
+package rancher
+
+/**
+ * Orchestration Hnadler using Rancher
+ */
+

--- a/upcloud/base.go
+++ b/upcloud/base.go
@@ -1,7 +1,7 @@
 package upcloud
 
 import (
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 /**
@@ -32,12 +32,12 @@ func (base *BaseUpcloudServiceHandler) BaseUpcloudServiceOperation() *BaseUpclou
 	return New_BaseUpcloudServiceOperation(base.factory, base.builderSettings)
 }
 
-// Get the service
+// Get the operations from the handler
 func (base *BaseUpcloudServiceHandler) Operations() *api_operation.Operations {
 	return base.operations
 }
 
-// Get the service
+// Get the factory
 func (base *BaseUpcloudServiceHandler) Factory() UpcloudFactory {
 	return base.factory
 }

--- a/upcloud/base.go
+++ b/upcloud/base.go
@@ -1,7 +1,7 @@
 package upcloud
 
 import (
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 /**

--- a/upcloud/builder.go
+++ b/upcloud/builder.go
@@ -3,15 +3,15 @@ package upcloud
 import (
 	log "github.com/Sirupsen/logrus"
 
-	api_api "github.com/james-nesbitt/kraut-api/api"
-	api_builder "github.com/james-nesbitt/kraut-api/builder"
-	api_handler "github.com/james-nesbitt/kraut-api/handler"
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+	api_api "github.com/james-nesbitt/radi-api/api"
+	api_builder "github.com/james-nesbitt/radi-api/builder"
+	api_handler "github.com/james-nesbitt/radi-api/handler"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
 )
 
 /**
- * A kraut builder for upcloud handlers
+ * A radi builder for upcloud handlers
  */
 
 // Upcloud Builder

--- a/upcloud/builder.go
+++ b/upcloud/builder.go
@@ -3,11 +3,11 @@ package upcloud
 import (
 	log "github.com/Sirupsen/logrus"
 
-	api_api "github.com/james-nesbitt/radi-api/api"
-	api_builder "github.com/james-nesbitt/radi-api/builder"
-	api_handler "github.com/james-nesbitt/radi-api/handler"
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_api "github.com/wunderkraut/radi-api/api"
+	api_builder "github.com/wunderkraut/radi-api/builder"
+	api_handler "github.com/wunderkraut/radi-api/handler"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
 )
 
 /**

--- a/upcloud/factory_configyml.go
+++ b/upcloud/factory_configyml.go
@@ -13,7 +13,7 @@ import (
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 	upcloud_service "github.com/Jalle19/upcloud-go-sdk/upcloud/service"
 
-	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+	api_config "github.com/james-nesbitt/radi-api/operation/config"
 )
 
 /**

--- a/upcloud/factory_configyml.go
+++ b/upcloud/factory_configyml.go
@@ -13,7 +13,7 @@ import (
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 	upcloud_service "github.com/Jalle19/upcloud-go-sdk/upcloud/service"
 
-	api_config "github.com/james-nesbitt/radi-api/operation/config"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
 )
 
 /**

--- a/upcloud/monitor.go
+++ b/upcloud/monitor.go
@@ -7,7 +7,7 @@ import (
 
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 /**
@@ -255,7 +255,7 @@ func (listServers *UpcloudMonitorListServersOperation) Exec() api_operation.Resu
 				}
 
 				if !filterOut {
-					log.WithFields(log.Fields{"index": index, "uuid": server.UUID, "title": server.Title, "plan": server.Plan, "zone": server.Zone, "state": server.State, "tags": server.Tags}).Info("Server")
+					log.WithFields(log.Fields{"index": index, "uuid": server.UUID, "title": server.Title, "plan": server.Plan, "zone": server.Zone, "state": server.State, "progress": server.Progress, "tags": server.Tags}).Info("Server")
 				}
 			}
 		} else {
@@ -305,7 +305,6 @@ func (serverDetail *UpcloudMonitorServerDetailsOperation) Validate() bool {
 func (serverDetail *UpcloudMonitorServerDetailsOperation) Properties() *api_operation.Properties {
 	if serverDetail.properties == nil {
 		props := api_operation.Properties{}
-
 		props.Add(api_operation.Property(&UpcloudGlobalProperty{}))
 		props.Add(api_operation.Property(&UpcloudServerUUIDSProperty{}))
 

--- a/upcloud/monitor.go
+++ b/upcloud/monitor.go
@@ -7,7 +7,7 @@ import (
 
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 /**

--- a/upcloud/property.go
+++ b/upcloud/property.go
@@ -6,7 +6,7 @@ import (
 	upcloud "github.com/Jalle19/upcloud-go-sdk/upcloud"
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 /**
@@ -304,14 +304,14 @@ func (request *UpcloudServerCreateRequestProperty) Type() string {
 }
 
 func (request *UpcloudServerCreateRequestProperty) Get() interface{} {
-	// // prov_project := "krauttest"
+	// // prov_project := "raditest"
 	// prov_zone := "fi-hel1"
 
 	// prov_initscript := "" // Initialize script. Can be a URL
 
 	// prov_user := upcloud_request.LoginUser{
 	// 	CreatePassword: "no", // Allow SSH only with key
-	// 	Username:       "kraut",
+	// 	Username:       "radi",
 	// 	SSHKeys: []string{
 	// 		"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDEI7j4EaK2RRKgp7rA9gDIL279WtNBWsPQwKn6YNjb7i1EUAM+IYzdQbPgpYr0rMx67DhvbK1pBeL0HTXfk1ZnSbbZe2xktk+YJo6l8zQ7wYydWMcCcB5HUvgG1/ugTj6wxImYAx7sEuXY4MVO7aHmfMnjV+7Re0uXHjAPL9k5O2Xvt75RmrgG8YpE6MvZtYTzIRmINbuSAX9CWKi46ZuRNYKDyZTSarqA1TOaGKiO6vf2dM7bWqsvitOxwEC6Z0c5nIAjcAGhg+yBEEloWTqNqkxPzbh0AIIO9HjGlnbSaIffwrv78UzrHatukUQOcsg6PBvMPvhjdoB0JrscLneDy0DhF6ptAQporg3SieypB/3hiZ0RfT94c35DQufFphfsphIBXIsqENJKR383sz57PPDtVgyXKSu5ujhXUPgC1rwldGUqVtMLsvC4tcnOIbOK917QjUQ+8cJoC08XBUG10knUoIWP8ebv55sfnBTHW27g+4B1V6ub3Zyq/ZRzeJXWzSh1QmOUXp1Q47bEz3eT2/VRtKyUYAo3ChvceMSERsVtwfRgIcAreIqGy2GJQPe7NkYOAPrirwhfppoFJ/nx3xGFjg0iZIg4Z1nTpwEWBWcC5eo/yfORnhdAooJWRYO37nOrjryUZJsRbFC/Uj7JOIX2QrZEX1bm4SwgSF8tTQ==", // JRN
 	// 	},
@@ -421,7 +421,7 @@ func (request *UpcloudServerCreateRequestProperty) Get() interface{} {
 	// 	},
 	// }
 
-	// // hardcoded_tag := "kraut-provisioned-" + prov_project
+	// // hardcoded_tag := "radi-provisioned-" + prov_project
 
 	// request.value = upcloud_request.CreateServerRequest{
 	// 	//AvoidHost  string `xml:"avoid_host,omitempty"`
@@ -436,7 +436,7 @@ func (request *UpcloudServerCreateRequestProperty) Get() interface{} {
 	// 	Plan:             "1xCPU-1GB",
 	// 	StorageDevices:   prov_storages,
 	// 	TimeZone:         "Europe/Helsinki",
-	// 	Title:            prov_project + ": provisioned automatically by kraut",
+	// 	Title:            prov_project + ": provisioned automatically by radi",
 	// 	UserData:         prov_initscript,
 	// 	//VNC: "off",
 	// 	Zone: prov_zone,

--- a/upcloud/property.go
+++ b/upcloud/property.go
@@ -6,7 +6,7 @@ import (
 	upcloud "github.com/Jalle19/upcloud-go-sdk/upcloud"
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 /**

--- a/upcloud/provision.go
+++ b/upcloud/provision.go
@@ -9,8 +9,8 @@ import (
 	upcloud "github.com/Jalle19/upcloud-go-sdk/upcloud"
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_provision "github.com/james-nesbitt/kraut-api/operation/provision"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_provision "github.com/james-nesbitt/radi-api/operation/provision"
 )
 
 /**

--- a/upcloud/provision.go
+++ b/upcloud/provision.go
@@ -9,8 +9,8 @@ import (
 	upcloud "github.com/Jalle19/upcloud-go-sdk/upcloud"
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_provision "github.com/james-nesbitt/radi-api/operation/provision"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_provision "github.com/wunderkraut/radi-api/operation/provision"
 )
 
 /**

--- a/upcloud/provision_server.go
+++ b/upcloud/provision_server.go
@@ -9,7 +9,7 @@ import (
 	upcloud "github.com/Jalle19/upcloud-go-sdk/upcloud"
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
 )
 
 /**

--- a/upcloud/provision_server.go
+++ b/upcloud/provision_server.go
@@ -9,7 +9,7 @@ import (
 	upcloud "github.com/Jalle19/upcloud-go-sdk/upcloud"
 	upcloud_request "github.com/Jalle19/upcloud-go-sdk/upcloud/request"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_operation "github.com/wunderkraut/radi-api/operation"
 )
 
 /**

--- a/upcloud/security.go
+++ b/upcloud/security.go
@@ -3,8 +3,8 @@ package upcloud
 import (
 	log "github.com/Sirupsen/logrus"
 
-	api_operation "github.com/james-nesbitt/kraut-api/operation"
-	api_security "github.com/james-nesbitt/kraut-api/operation/security"
+	api_operation "github.com/james-nesbitt/radi-api/operation"
+	api_security "github.com/james-nesbitt/radi-api/operation/security"
 )
 
 /**

--- a/upcloud/security.go
+++ b/upcloud/security.go
@@ -3,8 +3,8 @@ package upcloud
 import (
 	log "github.com/Sirupsen/logrus"
 
-	api_operation "github.com/james-nesbitt/radi-api/operation"
-	api_security "github.com/james-nesbitt/radi-api/operation/security"
+	api_operation "github.com/wunderkraut/radi-api/operation"
+	api_security "github.com/wunderkraut/radi-api/operation/security"
 )
 
 /**


### PR DESCRIPTION
This patch renames the project to radi, and moves it's library namespace to wunderkraut