### PR TITLE
made project settings come from only a single scope

### DIFF
--- a/configwrapper/builder_yaml.go
+++ b/configwrapper/builder_yaml.go
@@ -81,6 +81,7 @@ func (buildComponents *BuilderComponentsConfigWrapperYaml) Load() error {
 					log.WithFields(log.Fields{"ymlSettings": values, "key": key}).Debug("Each yml")
 					buildComponents.buildComponents.Set(key, *values.MakeBuildComponent())
 				}
+				break;
 			} else {
 				log.WithError(err).WithFields(log.Fields{"scope": scope}).Error("Couldn't marshall yml scope")
 			}
@@ -131,5 +132,8 @@ func (ymlSettingsProvider *Yml_BuildSettingSettingsProvider) UnmarshalYAML(unmar
 
 // UnMarshaller function
 func (ymlSettingsProvider Yml_BuildSettingSettingsProvider) AssignSettings(target interface{}) error {
-	return ymlSettingsProvider.UnMarshaler(target)
+	if ymlSettingsProvider.UnMarshaler != nil {
+		return ymlSettingsProvider.UnMarshaler(target)
+	}
+	return nil
 }


### PR DESCRIPTION
This patch implements 2 changes to the way that the project yml config is handled:

1. project config comes only from one scope, that of the highest priority found
2. missing yml does not produce a null reference error, if no 'settings' are provided for a project implementation.

This should implement the suggested solution for https://github.com/wunderkraut/radi-handlers/issues/6