### PR TITLE
Fix rancher timeout

### DIFF
--- a/libcompose/base.go
+++ b/libcompose/base.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	"io"
 
-	"golang.org/x/net/context"
+	"context"
 
 	api_operation "github.com/wunderkraut/radi-api/operation"
 	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"

--- a/libcompose/command_yaml.go
+++ b/libcompose/command_yaml.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"golang.org/x/net/context"
+	"context"
 	"gopkg.in/yaml.v2"
 
 	libCompose_config "github.com/docker/libcompose/config"
@@ -168,9 +168,9 @@ type CommandYmlCommand struct {
 	persistant bool
 	internal   bool
 
-	project       *ComposeProject
-	properties    *api_operation.Properties
-	serviceConfig libCompose_config.ServiceConfig
+	project           *ComposeProject
+	projectProperties *api_operation.Properties
+	serviceConfig     libCompose_config.ServiceConfig
 }
 
 // Yaml UnMarshaller
@@ -205,9 +205,7 @@ func (comm *CommandYmlCommand) UnmarshalYAML(unmarshal func(interface{}) error) 
 
 // Turn this CommandYmlCommand into a command.Command
 func (ymlCommand *CommandYmlCommand) Command(projectProps *api_operation.Properties) api_command.Command {
-	// merge the properties, keeping local over project.
-	projectProps.Merge(ymlCommand.Properties())
-	ymlCommand.properties = projectProps
+	ymlCommand.projectProperties = projectProps
 	return api_command.Command(ymlCommand)
 }
 
@@ -278,7 +276,7 @@ func (ymlCommand *CommandYmlCommand) Exec(props *api_operation.Properties) api_o
 	service := ymlCommand.serviceConfig
 
 	// create a libcompose project
-	project, _ := MakeComposeProject(props)
+	project, _ := MakeComposeProject(ymlCommand.projectProperties)
 
 	// allow our app to alter the service, to do some string replacements etc
 	project.AlterService(&service)

--- a/libcompose/libcompose.go
+++ b/libcompose/libcompose.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	log "github.com/Sirupsen/logrus"
-	"golang.org/x/net/context"
+	"context"
 
 	libCompose_docker "github.com/docker/libcompose/docker"
 	libCompose_dockerctx "github.com/docker/libcompose/docker/ctx"

--- a/libcompose/monitor.go
+++ b/libcompose/monitor.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-	"golang.org/x/net/context"
+	"context"
 
 	api_operation "github.com/wunderkraut/radi-api/operation"
 	api_monitor "github.com/wunderkraut/radi-api/operation/monitor"

--- a/libcompose/orchestrate_down.go
+++ b/libcompose/orchestrate_down.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	"errors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 

--- a/libcompose/orchestrate_start.go
+++ b/libcompose/orchestrate_start.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	"errors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	api_operation "github.com/wunderkraut/radi-api/operation"
 	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"

--- a/libcompose/orchestrate_stop.go
+++ b/libcompose/orchestrate_stop.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	"errors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	api_operation "github.com/wunderkraut/radi-api/operation"
 	api_orchestrate "github.com/wunderkraut/radi-api/operation/orchestrate"

--- a/libcompose/orchestrate_up.go
+++ b/libcompose/orchestrate_up.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	"errors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 

--- a/libcompose/property.go
+++ b/libcompose/property.go
@@ -118,7 +118,7 @@ func (contextConf *LibcomposeContextProperty) Label() string {
 
 // Description for the Property
 func (contextConf *LibcomposeContextProperty) Description() string {
-	return "A golang.org/x/net/context for controling execution."
+	return "A context for controling execution."
 }
 
 // Is the Property internal only

--- a/local/api.go
+++ b/local/api.go
@@ -1,7 +1,7 @@
 package local
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
 )

--- a/rancher/configsource_yml.go
+++ b/rancher/configsource_yml.go
@@ -122,7 +122,6 @@ func (settings *RancherSettings_yml) RancherClientSettings() RancherClientSettin
 		Url:       "http://127.0.0.1:8080/v2-beta",
 		AccessKey: "75AAAFB2BCFA7DD83BE2",
 		SecretKey: "XMJM2EgZia7ohYKpyfXPZxdq63C3UJEGe8qBYnt4",
-		Timeout:   0,
 	}
 	log.WithFields(log.Fields{"settings": clientSettings}).Debug("OVERRIDE RANCHER CLIENT SETTINGS WITH SOME MANUAL VALUE")
 	return clientSettings

--- a/rancher/settings.go
+++ b/rancher/settings.go
@@ -1,8 +1,6 @@
 package rancher
 
 import (
-	"time"
-
 	rancher_client "github.com/rancher/go-rancher/client"
 )
 
@@ -16,7 +14,6 @@ type RancherClientSettings struct {
 	Url       string
 	AccessKey string
 	SecretKey string
-	Timeout   time.Duration
 }
 
 // Convert RancherSettings to the rancher library client settings object natively.
@@ -25,7 +22,6 @@ func (settings *RancherClientSettings) rancher_client_ClientOpts() rancher_clien
 		Url:       settings.Url,
 		AccessKey: settings.AccessKey,
 		SecretKey: settings.SecretKey,
-		Timeout:   settings.Timeout,
 	}
 }
 


### PR DESCRIPTION
This patch fixes the rancher handler for an upstream change: Timeout was dropped as a property of client settings.

Also snuck in was the general replacement of "golang.org/x/net/context" for "context".