### PR TITLE
removed handlers that are only README files

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -1,5 +1,0 @@
-CONSUL
-======
-
-Connect to a Consul Agent to provide Operations based on
-service discovery and key value management.

--- a/kontena/README.md
+++ b/kontena/README.md
@@ -1,5 +1,0 @@
-Kontena
-=======
-
-Provide Kontena based orchestration through
-a custom Handler.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,5 +1,0 @@
-KUBERNETES
-==========
-
-Operation handler that connects to kubernetes for orchestrations and 
-commands.

--- a/rsa/README.md
+++ b/rsa/README.md
@@ -1,5 +1,0 @@
-RSA
-===
-
-RSA adds a handler which provides primarily security authentication
-operations, via RSA application on passed configurations.


### PR DESCRIPTION
This patch removes handlers that were only placeholders.  Originally we declared what handlers we thought wouold be a good idea, and then worked only on the higher priority items. Now handlers will likely be moved to their own libraries, so won't need those items here.