### PR TITLE
Default user to os user

### DIFF
--- a/configwrapper/security.go
+++ b/configwrapper/security.go
@@ -29,16 +29,16 @@ type SecurityConfigWrapper interface {
  * that are based on using the Wrapper
  */
 
+// SecurityWrapper base operation
+type SecurityWrapperBaseOperation struct {
+	securityConfigWrapper SecurityConfigWrapper
+}
+
 // Constructor for SecurityWrapperBaseOperation
 func New_SecurityWrapperBaseOperation(wrapper SecurityConfigWrapper) *SecurityWrapperBaseOperation {
 	return &SecurityWrapperBaseOperation{
 		securityConfigWrapper: wrapper,
 	}
-}
-
-// SecurityWrapper base operation
-type SecurityWrapperBaseOperation struct {
-	securityConfigWrapper SecurityConfigWrapper
 }
 
 // Get the security wrapper
@@ -73,7 +73,6 @@ func (userOp *SecurityConfigWrapperUserOperation) Properties() api_operation.Pro
 // Execute the Operation
 //
 // @TODO Better error checking is needed in this exec
-// @TODO Make this threaded and non-blocking
 func (userOp *SecurityConfigWrapperUserOperation) Exec(props *api_operation.Properties) api_operation.Result {
 	result := api_operation.New_StandardResult()
 

--- a/configwrapper/security_yaml_user.go
+++ b/configwrapper/security_yaml_user.go
@@ -1,14 +1,9 @@
 package configwrapper
 
 import (
-	// "errors"
-	// "regexp"
-
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	// api_operation "github.com/wunderkraut/radi-api/operation"
-	// api_config "github.com/wunderkraut/radi-api/operation/config"
 	api_security "github.com/wunderkraut/radi-api/operation/security"
 )
 
@@ -29,7 +24,7 @@ func (security *SecurityConfigWrapperYml) LoadUser() error {
 		}
 		return nil
 	} else {
-		log.WithError(err).Error("Error loading config for " + CONFIG_KEY_SECURITY_USER)
+		log.WithFields(log.Fields{"config-key": CONFIG_KEY_SECURITY_USER}).WithError(err).Warn("Config wrapper could not load any user definition/configuration")
 		return err
 	}
 }

--- a/local/api.go
+++ b/local/api.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"os/user"
 
 	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
 )
@@ -10,4 +11,5 @@ import (
 type LocalAPISettings struct {
 	handlers_bytesource.BytesourceFileSettings
 	Context context.Context
+	User user.User
 }

--- a/local/builder.go
+++ b/local/builder.go
@@ -25,13 +25,6 @@ import (
  * the Handlers that are defined in the other files.
  */
 
-// Constructor for LocalBuilder
-func New_LocalBuilder(settings LocalAPISettings) *LocalBuilder {
-	return &LocalBuilder{
-		settings: settings,
-	}
-}
-
 // Provide a handler for building all local operations
 type LocalBuilder struct {
 	settings LocalAPISettings
@@ -47,6 +40,13 @@ type LocalBuilder struct {
 	Setting     api_setting.SettingWrapper
 	Orchestrate api_orchestrate.OrchestrateWrapper
 	Security    api_security.SecurityWrapper
+}
+
+// Constructor for LocalBuilder
+func New_LocalBuilder(settings LocalAPISettings) *LocalBuilder {
+	return &LocalBuilder{
+		settings: settings,
+	}
 }
 
 // IBuilder ID


### PR DESCRIPTION
This patch makes the local handler SecurityUser retrieval default to try to user the os/User from localsettings, if one was supplied.  This provides a fallback user for cases where no explicity user was provided in config.

There is also some code cleanup, and message improvements in the ConfigWrapper handler

This depends on https://github.com/wunderkraut/radi-api/pull/8