### PR TITLE
local project generate now allows skip files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "vendor/github.com/james-nesbitt/init-go"]
 	path = vendor/github.com/james-nesbitt/init-go
 	url = https://github.com/james-nesbitt/init-go.git
-	branch = master
+	branch = 94fcc5d0a408896a653847f7078deac13422c76b
 [submodule "vendor/gopkg.in/yaml.v2"]
 	path = vendor/gopkg.in/yaml.v2
 	url = https://gopkg.in/yaml.v2


### PR DESCRIPTION
With this patch, you can now pass in a list of files to skip, when generating templates.

This patch also always skips a top level .git path (why would you template a single git clone, when it is better to just tell people to use the git clone)

This involved a patch to the upstream project: https://github.com/james-nesbitt/init-go/pull/6